### PR TITLE
Feature/make translations data formatable

### DIFF
--- a/packages/translations/README.md
+++ b/packages/translations/README.md
@@ -9,20 +9,30 @@ A hook which loads the translations from an external source and initializes i18n
 ## Usage
 
 ```
-import { useTranslations } from '@bothrs/translations
+import { useTranslations } from '@bothrs/translations'
 ```
 
 `useTranslations` return a boolean which indicates if the translations are loaded. This can be used to [hide the splashscreen](https://docs.expo.dev/versions/latest/sdk/splash-screen/).
 
 ```
-const translationsLoaded = useTranslations({
+  const translationsLoaded = useInitI18Next({
     expirationTime: 60 * 1000,
-    startupLanguage: 'en',
-    loadPath: airtableUrl + '/Translations' + '?api_key=' + airtableKey,
-})
-
-
+    startupLanguage: 'nl',
+    fallbackLng: 'nl',
+    loadPath: api + 'translations',
+    dataFormatter: data => {
+      return data.translations
+    },
+  })
 ```
+
+| Name            | Explanation                                                                                          |
+| --------------- | ---------------------------------------------------------------------------------------------------- |
+| expirationTime  | Time between translation refreshes in ms                                                             |
+| startupLanguage | startup language                                                                                     |
+| fallbackLng     | fallback language                                                                                    |
+| loadPath        | The endpoint from where the translations will be loaded                                              |
+| dataFormatter   | A function which allows you to format the data fetched so it matches the `FormattedTranslation` type |
 
 ## Airtable
 

--- a/packages/translations/src/index.ts
+++ b/packages/translations/src/index.ts
@@ -26,7 +26,7 @@ export function useTranslations(initParams: TranslationInitParams): boolean {
     setInitialized(true)
   }
 
-  initTranslations(initParams)
+  !initialized && initTranslations(initParams)
 
   useEffect(() => {
     i.on('initialized', handleInitialized)
@@ -41,6 +41,7 @@ function initTranslations({
   startupLanguage,
   expirationTime,
   fallbackLng,
+  dataFormatter,
 }: TranslationInitParams) {
   const fetchOptions = {
     loadPath,
@@ -48,7 +49,9 @@ function initTranslations({
     parse: function (data: string) {
       const parsedData = JSON.parse(data)
 
-      const translationData: FormattedTranslation[] = parsedData.translations
+      const translationData: FormattedTranslation[] = dataFormatter
+        ? dataFormatter(parsedData as object)
+        : parsedData
 
       const langSet = new Set()
 
@@ -87,19 +90,13 @@ function initTranslations({
       { backend: Fetch, backendOption: fetchOptions },
     ],
   }
-  // if (process.env.NODE_ENV === 'test') {
-  //   backend = {
-  //     backends: [AsyncStorageBackend],
-  //     backendOptions: [asyncOptions],
-  //   }
-  // }
 
   i.use(ChainedBackend).init({
     ns: 'app',
     defaultNS: 'app',
     fallbackLng: fallbackLng || 'en',
     lng: startupLanguage,
-    load: 'languageOnly',
+    load: 'all',
     keySeparator: false,
     nsSeparator: false,
     interpolation: {

--- a/packages/translations/src/types/index.ts
+++ b/packages/translations/src/types/index.ts
@@ -37,4 +37,5 @@ export interface TranslationInitParams {
   expirationTime: number
   /** fallback language if startupLanguage fails, defaults to "en" */
   fallbackLng?: string
+  dataFormatter?: (data: any) => FormattedTranslation[]
 }


### PR DESCRIPTION
<!-- Add a list of features/ bugs/ ... that this PR handles -->
## What
* allows the user to shape the data fetched from the endpoint to the expected format. Now the package is not airtable specific and can be used with all types of endpoints.

<!-- List all the context the reviewer needs -->
## How
* add a dataFormatter option



<!-- Add a screenshot/ screencapture/ loom -->
## Demo

``` 
  const translationsLoaded = useInitI18Next({
    expirationTime: 60 * 1000,
    startupLanguage: 'nl',
    fallbackLng: 'nl',
    loadPath: api + 'translations',
    dataFormatter: data => {
      return data.translations
    },
  })
```
![simulator_screenshot_478AE1CC-BC6A-4114-9821-CAE59AAB5841](https://user-images.githubusercontent.com/36442007/141066671-6ef5cd44-0ebb-4bb9-8bfb-569628cb06b3.png)


