### PR TITLE
fix: check the amount of font families

### DIFF
--- a/packages/zero-height/src/fixFontFamilies.ts
+++ b/packages/zero-height/src/fixFontFamilies.ts
@@ -14,9 +14,11 @@ export function fixFontFamilies(
 
     if (key === 'font-family') {
       const originalFontFamily = value
-      const fixedFontFamily = originalFontFamily
-        .split(', ')
-        [framework === 'expo' ? 1 : 0].split("'")
+
+      const fontFamilies = originalFontFamily.split(', ')
+
+      const fixedFontFamily = fontFamilies
+        [framework === 'expo' ? fontFamilies.length-1 : 0].split("'")
         .join('')
 
       if (fixedFontFamily) {


### PR DESCRIPTION
## What
<!-- Add a list of features/ bugs/ ... that this PR handles -->
- bug fix when there was only one font in the font-families property
![image](https://user-images.githubusercontent.com/36442007/159921403-0e4597e1-4a70-4574-b425-b79cc77d9a3c.png)


## How
<!-- List all the context the reviewer needs -->
- check the amount of fonts




