### PR TITLE
fix: ScrollViewStickyBottom types breaking TS builds in Next.js

### DIFF
--- a/packages/react-native-layout/src/components/scroll-view-sticky-bottom/ScrollViewStickyBottom.props.ts
+++ b/packages/react-native-layout/src/components/scroll-view-sticky-bottom/ScrollViewStickyBottom.props.ts
@@ -1,7 +1,7 @@
+import type { TestableComponent } from '../../types/generic-props'
 import type React from 'react'
 import type { StyleProp, ViewStyle } from 'react-native'
 import type { KeyboardAwareScrollViewProps } from 'react-native-keyboard-aware-scroll-view'
-import type { TestableComponent } from 'src/types/generic-props'
 
 type ScrollViewStickyBottomProps = TestableComponent &
   KeyboardAwareScrollViewProps & {


### PR DESCRIPTION
## What

- [x] Minor fix for breaking builds when using `@bothrs/react-native-layout` with Next.js

## Demo

Verified to work with `patch-package` in [Bothrs/walmart-daly#327](https://github.com/bothrs/walmart-daly/pull/327/files#r1127555087)