### PR TITLE
chore: disable auto-focus rule for input fields

### DIFF
--- a/packages/biome-config/root.biome.json
+++ b/packages/biome-config/root.biome.json
@@ -22,6 +22,7 @@
   "linter": {
     "rules": {
       "a11y": {
+        "noAutofocus": "off",
         "noSvgWithoutTitle": "off"
       },
       "suspicious": {


### PR DESCRIPTION
## Summary

Adjusted root linter config for auto-focus of input fields

## Changes

- Disabled auto-focus linting rule

## Reason
In some cases when a user attempts to edit a field it should autofocus an input field.

For example, an action sheet where the user chooses the "edit" action should auto focus the field that he wants to edit.