### PR TITLE
feat: enable useBlockStatements and useConsistentTypeDefinitions

### DIFF
--- a/packages/biome-config/root.biome.json
+++ b/packages/biome-config/root.biome.json
@@ -41,6 +41,15 @@
           "fix": "safe",
           "level": "warn"
         }
+      },
+      "style": {
+        "useBlockStatements": "error",
+        "useConsistentTypeDefinitions": {
+          "level": "error",
+          "options": {
+            "style": "type"
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
## Summary
- Enable `useBlockStatements` (error) — require braces on `if`/`else`/loops
- Enable `useConsistentTypeDefinitions` (error) with `style: "type"` — prefer `type` over `interface`